### PR TITLE
refactor: move data definitions to impl module and improve null safety

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -10,13 +10,30 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        run: |
+          curl https://mise.run | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install toolchain (mise)
+        run: |
+          mise install
+          mise activate
+
+      - name: Verify Java version
+        run: java -version
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: run build with fastlane
+      - name: Install Ruby gems
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Run build with Fastlane
         run: bundle exec fastlane assemble
 
-      - name: run tests with fastlane
+      - name: Run tests with Fastlane
         run: bundle exec fastlane test

--- a/data/bridge/src/main/java/com/caioluis/githubpopular/data/bridge/mappers/EntityMappers.kt
+++ b/data/bridge/src/main/java/com/caioluis/githubpopular/data/bridge/mappers/EntityMappers.kt
@@ -13,24 +13,24 @@ fun RemoteGitHubRepository.toDomain(
     language: String,
 ) = DomainGitHubRepository(
     id = id ?: -1,
-    name = name ?: "",
-    fullName = fullName ?: "",
+    name = name.orEmpty(),
+    fullName = fullName.orEmpty(),
     owner =
     owner?.toDomain()
         ?: DomainRepositoryOwner(),
-    description = description ?: "",
-    pullsUrl = pullsUrl ?: "",
+    description = description.orEmpty(),
+    pullsUrl = pullsUrl.orEmpty(),
     stargazersCount = stargazersCount ?: 0,
     forksCount = forksCount ?: 0,
-    htmlUrl = htmlUrl ?: "",
+    htmlUrl = htmlUrl.orEmpty(),
     page = page,
     language = language,
 )
 
 fun RemoteRepositoryOwner.toDomain() = DomainRepositoryOwner(
     id = id ?: -1,
-    login = login ?: "",
-    avatarUrl = avatarUrl ?: "",
+    login = login.orEmpty(),
+    avatarUrl = avatarUrl.orEmpty(),
 )
 
 // Local

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/di/DataModule.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/di/DataModule.kt
@@ -1,16 +1,16 @@
 package com.caioluis.githubpopular.data.impl.di
 
 import android.content.Context
-import com.caioluis.githubpopular.data.bridge.local.LocalSource
-import com.caioluis.githubpopular.data.bridge.local.dao.GitHubRepositoriesDao
-import com.caioluis.githubpopular.data.bridge.remote.RemoteSource
-import com.caioluis.githubpopular.data.bridge.remote.service.GitHubRepositoriesService
 import com.caioluis.githubpopular.data.impl.BuildConfig
 import com.caioluis.githubpopular.data.impl.local.GitHubReposDataBase
 import com.caioluis.githubpopular.data.impl.local.LocalSourceImpl
+import com.caioluis.githubpopular.data.impl.local.dao.GitHubRepositoriesDao
+import com.caioluis.githubpopular.data.impl.local.model.LocalSource
 import com.caioluis.githubpopular.data.impl.remote.GitHubReposRepositoryImpl
+import com.caioluis.githubpopular.data.impl.remote.RemoteSource
 import com.caioluis.githubpopular.data.impl.remote.RemoteSourceImpl
 import com.caioluis.githubpopular.data.impl.remote.ServiceBuilder
+import com.caioluis.githubpopular.data.impl.remote.service.GitHubRepositoriesService
 import com.caioluis.githubpopular.domain.bridge.repository.GitHubReposRepository
 import dagger.Binds
 import dagger.Module

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/local/GitHubReposDataBase.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/local/GitHubReposDataBase.kt
@@ -5,8 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
-import com.caioluis.githubpopular.data.bridge.local.dao.GitHubRepositoriesDao
 import com.caioluis.githubpopular.data.bridge.local.model.LocalGitHubRepository
+import com.caioluis.githubpopular.data.impl.local.dao.GitHubRepositoriesDao
 import com.caioluis.githubpopular.data.impl.local.typeconverter.RepositoryOwnerConverter
 
 const val DATABASE_FILE_NAME = "GitHubPopular.db"

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/local/LocalSourceImpl.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/local/LocalSourceImpl.kt
@@ -1,9 +1,9 @@
 package com.caioluis.githubpopular.data.impl.local
 
-import com.caioluis.githubpopular.data.bridge.local.LocalSource
-import com.caioluis.githubpopular.data.bridge.local.dao.GitHubRepositoriesDao
 import com.caioluis.githubpopular.data.bridge.mappers.toDomain
 import com.caioluis.githubpopular.data.bridge.mappers.toLocal
+import com.caioluis.githubpopular.data.impl.local.dao.GitHubRepositoriesDao
+import com.caioluis.githubpopular.data.impl.local.model.LocalSource
 import com.caioluis.githubpopular.domain.bridge.entity.DomainGitHubRepository
 import javax.inject.Inject
 
@@ -26,7 +26,7 @@ constructor(
     override suspend fun getFromCache(
         page: Int,
         language: String,
-    ): List<DomainGitHubRepository>? = gitHubRepositoriesDao.getAllRepositories(page, language)?.map {
+    ): List<DomainGitHubRepository> = gitHubRepositoriesDao.getAllRepositories(page, language).map {
         it.toDomain()
     }
 }

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/local/dao/GitHubRepositoriesDao.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/local/dao/GitHubRepositoriesDao.kt
@@ -1,4 +1,4 @@
-package com.caioluis.githubpopular.data.bridge.local.dao
+package com.caioluis.githubpopular.data.impl.local.dao
 
 import androidx.room.Dao
 import androidx.room.Insert
@@ -18,7 +18,7 @@ interface GitHubRepositoriesDao {
     suspend fun getAllRepositories(
         page: Int,
         language: String,
-    ): List<LocalGitHubRepository>?
+    ): List<LocalGitHubRepository>
 
     @Query("DELETE FROM GitHubRepositories WHERE language=:language COLLATE NOCASE")
     suspend fun deleteReposByLanguage(language: String)

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/local/model/LocalSource.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/local/model/LocalSource.kt
@@ -1,4 +1,4 @@
-package com.caioluis.githubpopular.data.bridge.local
+package com.caioluis.githubpopular.data.impl.local.model
 
 import com.caioluis.githubpopular.domain.bridge.entity.DomainGitHubRepository
 
@@ -12,5 +12,5 @@ interface LocalSource {
     suspend fun getFromCache(
         page: Int,
         language: String,
-    ): List<DomainGitHubRepository>?
+    ): List<DomainGitHubRepository>
 }

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/GitHubReposRepositoryImpl.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/GitHubReposRepositoryImpl.kt
@@ -1,9 +1,7 @@
 package com.caioluis.githubpopular.data.impl.remote
 
-import com.caioluis.githubpopular.data.bridge.local.LocalSource
 import com.caioluis.githubpopular.data.bridge.mappers.toDomain
-import com.caioluis.githubpopular.data.bridge.remote.NoMoreItemsException
-import com.caioluis.githubpopular.data.bridge.remote.RemoteSource
+import com.caioluis.githubpopular.data.impl.local.model.LocalSource
 import com.caioluis.githubpopular.domain.bridge.entity.DomainGitHubRepository
 import com.caioluis.githubpopular.domain.bridge.repository.GitHubReposRepository
 import javax.inject.Inject
@@ -26,7 +24,7 @@ constructor(
             } ?: throw NoMoreItemsException()
     }.getOrElse { previousError ->
         localSource.getFromCache(page, language)
-            ?.takeIf { it.isNotEmpty() }
+            .takeIf { it.isNotEmpty() }
             ?: throw previousError
     }
 }

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/NoMoreItemsException.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/NoMoreItemsException.kt
@@ -1,3 +1,3 @@
-package com.caioluis.githubpopular.data.bridge.remote
+package com.caioluis.githubpopular.data.impl.remote
 
 class NoMoreItemsException : Exception(("No more items to show"))

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/RemoteSource.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/RemoteSource.kt
@@ -1,4 +1,4 @@
-package com.caioluis.githubpopular.data.bridge.remote
+package com.caioluis.githubpopular.data.impl.remote
 
 import com.caioluis.githubpopular.data.bridge.remote.model.RemoteGitHubRepository
 

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/RemoteSourceImpl.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/RemoteSourceImpl.kt
@@ -1,8 +1,7 @@
 package com.caioluis.githubpopular.data.impl.remote
 
-import com.caioluis.githubpopular.data.bridge.remote.RemoteSource
 import com.caioluis.githubpopular.data.bridge.remote.model.RemoteGitHubRepository
-import com.caioluis.githubpopular.data.bridge.remote.service.GitHubRepositoriesService
+import com.caioluis.githubpopular.data.impl.remote.service.GitHubRepositoriesService
 import javax.inject.Inject
 
 class RemoteSourceImpl

--- a/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/service/GitHubRepositoriesService.kt
+++ b/data/impl/src/main/java/com/caioluis/githubpopular/data/impl/remote/service/GitHubRepositoriesService.kt
@@ -1,4 +1,4 @@
-package com.caioluis.githubpopular.data.bridge.remote.service
+package com.caioluis.githubpopular.data.impl.remote.service
 
 import com.caioluis.githubpopular.data.bridge.remote.model.RemoteGitHubRepositories
 import retrofit2.http.GET

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+java = "21.0.2"
+
+# Ruby for Fastlane
+ruby = "3.4.8"


### PR DESCRIPTION
- Move `LocalSource`, `RemoteSource`, `GitHubRepositoriesDao`, `GitHubRepositoriesService`, and `NoMoreItemsException` from `data/bridge` to `data/impl` package
- Update `DataModule`, `GitHubReposRepositoryImpl`, and related classes to reflect the package structure changes
- Change return types of `LocalSource` and `GitHubRepositoriesDao` from nullable `List?` to non-nullable `List`
- Refactor `EntityMappers` to utilize Kotlin's `.orEmpty()` extension for string mapping