### PR TITLE
refactor: truncate description on ui model for list scroll performance

### DIFF
--- a/app/src/main/java/com/caioluis/githubpopular/extensions/StringExtensions.kt
+++ b/app/src/main/java/com/caioluis/githubpopular/extensions/StringExtensions.kt
@@ -1,0 +1,7 @@
+package com.caioluis.githubpopular.extensions
+
+fun String.truncate(limit: Int): String = if (length >= limit) {
+    "${take(limit)}..."
+} else {
+    this
+}

--- a/app/src/main/java/com/caioluis/githubpopular/mapper/UiMapper.kt
+++ b/app/src/main/java/com/caioluis/githubpopular/mapper/UiMapper.kt
@@ -2,15 +2,17 @@ package com.caioluis.githubpopular.mapper
 
 import com.caioluis.githubpopular.domain.bridge.entity.DomainGitHubRepository
 import com.caioluis.githubpopular.domain.bridge.entity.DomainRepositoryOwner
+import com.caioluis.githubpopular.extensions.truncate
 import com.caioluis.githubpopular.model.UiGitHubRepository
 import com.caioluis.githubpopular.model.UiRepositoryOwner
 
+private const val DESCRIPTION_CHAR_LIMIT = 300
 fun DomainGitHubRepository.toUi() = UiGitHubRepository(
     id = id,
     name = name,
     fullName = fullName,
     owner = owner.toUi(),
-    description = description,
+    description = description.truncate(DESCRIPTION_CHAR_LIMIT),
     pullsUrl = pullsUrl,
     stargazersCount = stargazersCount,
     htmlUrl = htmlUrl,

--- a/app/src/main/java/com/caioluis/githubpopular/viewmodel/GetRepositoriesViewModel.kt
+++ b/app/src/main/java/com/caioluis/githubpopular/viewmodel/GetRepositoriesViewModel.kt
@@ -9,6 +9,7 @@ import androidx.paging.cachedIn
 import androidx.paging.map
 import com.caioluis.githubpopular.data.GitHubPagingSource
 import com.caioluis.githubpopular.domain.bridge.usecase.GetRepositoriesUseCase
+import com.caioluis.githubpopular.mapper.toUi
 import com.caioluis.githubpopular.model.UiGitHubRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,19 +46,7 @@ class GetRepositoriesViewModel @Inject constructor(
                 .cachedIn(viewModelScope)
                 .collectLatest { pagingData ->
                     val uiPagingData = pagingData.map { domainRepo ->
-                        UiGitHubRepository(
-                            id = domainRepo.id,
-                            name = domainRepo.name,
-                            description = domainRepo.description,
-                            forksCount = domainRepo.forksCount,
-                            stargazersCount = domainRepo.stargazersCount,
-                            owner = domainRepo.owner.let { owner ->
-                                com.caioluis.githubpopular.model.UiRepositoryOwner(
-                                    avatarUrl = owner.avatarUrl,
-                                    login = owner.login,
-                                )
-                            },
-                        )
+                        domainRepo.toUi()
                     }
                     _repositories.value = uiPagingData
                 }


### PR DESCRIPTION
- Introduce `String.truncate` extension function to limit string length
- Update `UiMapper` to truncate repository descriptions to 300 characters
- Refactor `GetRepositoriesViewModel` to use `toUi()` mapper instead of manual object construction